### PR TITLE
Clause Database Reduction

### DIFF
--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -21,12 +21,12 @@ class CDCL {
     /**
      * Clause database.
      */
-    private val db: ClauseDatabase = ClauseDatabase()
+    private val db: ClauseDatabase = ClauseDatabase(this)
 
     /**
      * Assignment.
      */
-    private val assignment: Assignment = Assignment()
+    val assignment: Assignment = Assignment()
 
     /**
      * Can solver perform the search? This becomes false if given constraints
@@ -250,8 +250,10 @@ class CDCL {
             return SolveResult.UNSAT
         }
 
-        backtrack(0)
-        cachedModel = null
+        if (assignment.decisionLevel > 0) {
+            backtrack(0)
+            cachedModel = null
+        }
 
         variableSelector.build(db.clauses)
 
@@ -272,6 +274,7 @@ class CDCL {
                 if (assignment.decisionLevel == 0) {
                     // println("KoSat conflicts:   $numberOfConflicts")
                     // println("KoSat decisions:   $numberOfDecisions")
+                    ok = false
                     return SolveResult.UNSAT
                 }
 
@@ -308,6 +311,8 @@ class CDCL {
                     // println("KoSat decisions:   $numberOfDecisions")
                     return SolveResult.SAT
                 }
+
+                db.reduceIfNeeded()
 
                 // try to guess variable
                 assignment.newDecisionLevel()

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -39,7 +39,7 @@ class CDCL {
      *
      * `i`-th element of this list is the set of clauses watched by variable `i`.
      */
-    private val watchers: MutableList<MutableList<Clause>> = mutableListOf()
+    val watchers: MutableList<MutableList<Clause>> = mutableListOf()
 
     /**
      * The number of variables.

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -714,7 +714,7 @@ class CDCL {
         }
 
         require(lca != null)
-        return Clause(mutableListOf(lca.neg, clause[0]))
+        return Clause(mutableListOf(lca.neg, clause[0]), true)
     }
 
     // ---- Two watchers ---- //

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -48,10 +48,6 @@ class CDCL {
     var numberOfVariables: Int = 0
         private set
 
-    // controls the learned clause database reduction, should be replaced and moved in the future
-    private var reduceNumber = 6000.0
-    private var reduceIncrement = 500.0
-
     /**
      * The maximum amount of probes expected to be returned
      * by [generateProbes].
@@ -232,23 +228,6 @@ class CDCL {
         return result
     }
 
-    // half of learnt get reduced
-    fun reduceDB() {
-        db.learnts.sortByDescending { it.lbd }
-        val deletionLimit = db.learnts.size / 2
-        var cnt = 0
-        for (clause in db.learnts) {
-            if (cnt == deletionLimit) {
-                break
-            }
-            if (!clause.deleted) {
-                cnt++
-                clause.deleted = true
-            }
-        }
-        db.learnts.removeAll { it.deleted }
-    }
-
     // ---- Solve ---- //
 
     fun solve(): SolveResult {
@@ -313,11 +292,6 @@ class CDCL {
                     addLearnt(lemma)
                 }
 
-                // remove half of learnts
-                if (db.learnts.size > reduceNumber) {
-                    reduceNumber += reduceIncrement
-                    reduceDB()
-                }
                 variableSelector.update(lemma)
 
                 // restart search after some number of conflicts

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -30,8 +30,7 @@ class CDCL {
 
     /**
      * Can solver perform the search? This becomes false if given constraints
-     * cause unsatisfiability in a trivial way (e.g. empty clause, conflicting
-     * unit clauses) and whether the solver can continue the search.
+     * cause unsatisfiability in some way.
      */
     private var ok = true
 
@@ -185,6 +184,7 @@ class CDCL {
             variableSelector.backTrack(v)
         }
 
+        check(assignment.qhead >= assignment.trail.size)
         assignment.qhead = assignment.trail.size
         assignment.decisionLevel = level
     }
@@ -299,8 +299,7 @@ class CDCL {
                 variableSelector.update(lemma)
                 db.clauseDecayActivity()
 
-                // restart search after some number of conflicts
-                restarter.update()
+                restarter.numberOfConflictsAfterRestart++
             } else {
                 // NO CONFLICT
                 require(assignment.qhead == assignment.trail.size)
@@ -313,6 +312,7 @@ class CDCL {
                 }
 
                 db.reduceIfNeeded()
+                restarter.restartIfNeeded()
 
                 // try to guess variable
                 assignment.newDecisionLevel()

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -892,7 +892,7 @@ class CDCL {
                         minimizeMarks[it] != currentMinimizationMark
                     } ?: true
                 }.toMutableList(),
-                true,
+                learnt = true,
             )
 
             val uipIndex = newClause.lits.indexOfFirst { it.variable == v }

--- a/kosat-core/src/commonMain/kotlin/org/kosat/ClauseDatabase.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/ClauseDatabase.kt
@@ -103,9 +103,13 @@ class ClauseDatabase(private val solver: CDCL) {
         removeDeleted()
     }
 
+    // TODO: Move to solver parameters
     private var reduceMaxLearnts = 6000
     private val reduceMaxLearntsIncrement = 500
 
+    /**
+     * Run [reduce] if the number of learnt clauses is too high.
+     */
     fun reduceIfNeeded() {
         if (learnts.size > reduceMaxLearnts + solver.assignment.trail.size) {
             reduceMaxLearnts += reduceMaxLearntsIncrement

--- a/kosat-core/src/commonMain/kotlin/org/kosat/ClauseDatabase.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/ClauseDatabase.kt
@@ -42,6 +42,9 @@ class ClauseDatabase(private val solver: CDCL) {
         learnts.removeAll { it.deleted }
     }
 
+    /**
+     * @see simplify
+     */
     private fun simplifyClause(clause: Clause) {
         for (lit in clause.lits) {
             if (solver.assignment.fixed(lit) == LBool.TRUE) {
@@ -57,6 +60,10 @@ class ClauseDatabase(private val solver: CDCL) {
         check(clause.lits.size >= 2)
     }
 
+    /**
+     * Remove clauses, satisfied at level 0, and falsified literals at level 0
+     * in the remaining clauses.
+     */
     fun simplify() {
         for (clause in clauses) {
             if (clause.deleted) continue
@@ -69,6 +76,9 @@ class ClauseDatabase(private val solver: CDCL) {
         }
     }
 
+    /**
+     * Remove the least active learned clauses.
+     */
     private fun reduce() {
         simplify()
         removeDeleted()

--- a/kosat-core/src/commonMain/kotlin/org/kosat/ClauseDatabase.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/ClauseDatabase.kt
@@ -46,6 +46,10 @@ class ClauseDatabase(private val solver: CDCL) {
     fun removeDeleted() {
         clauses.removeAll { it.deleted }
         learnts.removeAll { it.deleted }
+
+        for (watched in solver.watchers) {
+            watched.removeAll { it.deleted }
+        }
     }
 
     /**

--- a/kosat-core/src/commonMain/kotlin/org/kosat/ClauseDatabase.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/ClauseDatabase.kt
@@ -83,16 +83,18 @@ class ClauseDatabase(private val solver: CDCL) {
         simplify()
         removeDeleted()
 
-        learnts.sortedByDescending { if (it.lits.size == 2) Double.POSITIVE_INFINITY else it.activity }
+        learnts.sortedBy { if (it.lits.size == 2) Double.POSITIVE_INFINITY else it.activity }
 
         val countLimit = learnts.size / 2
         val activityLimit = clauseInc / learnts.size.toDouble()
 
-        for (i in countLimit until learnts.size) {
+        for (i in 0 until countLimit) {
             val learnt = learnts[i]
 
-            if (learnt.lits.size == 2) continue
-            if (learnt.activity >= activityLimit) continue
+            if (learnt.lits.size == 2) break
+            if (learnt.activity >= activityLimit) break
+
+            // Do not delete clauses if they are used in the trail
             if (solver.assignment.reason(learnt[0].variable) === learnt) continue
 
             learnt.deleted = true

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Restarter.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Restarter.kt
@@ -5,7 +5,7 @@ class Restarter(private val solver: CDCL) {
 
     private val lubyMultiplierConstant = 50.0
     private var restartNumber = lubyMultiplierConstant
-    private var numberOfConflictsAfterRestart = 0
+    var numberOfConflictsAfterRestart = 0
 
     // 1, 1, 2, 1, 1, 2, 4, 1, 1, 2, 1, 1, 2, 4, 8, ...
     // return i'th element of luby sequence
@@ -26,16 +26,15 @@ class Restarter(private val solver: CDCL) {
 
     private var lubyPosition = 1
 
-    fun restart() {
+    private fun restart() {
         restartNumber = lubyMultiplierConstant * luby(lubyPosition++)
         solver.backtrack(0)
     }
 
-    fun update() {
-        numberOfConflictsAfterRestart++
+    fun restartIfNeeded() {
         if (numberOfConflictsAfterRestart >= restartNumber) {
-            numberOfConflictsAfterRestart = 0
             restart()
+            numberOfConflictsAfterRestart = 0
         }
     }
 }

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Restarter.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Restarter.kt
@@ -26,14 +26,11 @@ class Restarter(private val solver: CDCL) {
 
     private var lubyPosition = 1
 
-    private fun restart() {
-        restartNumber = lubyMultiplierConstant * luby(lubyPosition++)
-        solver.backtrack(0)
-    }
-
     fun restartIfNeeded() {
         if (numberOfConflictsAfterRestart >= restartNumber) {
-            restart()
+            restartNumber = lubyMultiplierConstant * luby(lubyPosition++)
+            solver.backtrack(0)
+
             numberOfConflictsAfterRestart = 0
         }
     }


### PR DESCRIPTION
- Implements activity based DB reduction with a switch to choose between default LBD and activity based strategy. 
- Adds simplify function to simplify clause DB based on level 0 assignments. 
- Does some minor changes to Restarter to make it all work together, including: 
  - `ok` is now set to `false` after `UNSAT` due to level 0 conflict to stop useless, and potentially broken, propagations on level 0 after subsequent invocations of `solve`.

A lot of documentation is yet to be written, will do after search procedure will stabilize a little more.