### PR TITLE
Global Solver Configuration

### DIFF
--- a/kosat-core/src/commonMain/kotlin/org/kosat/Configuration.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Configuration.kt
@@ -1,0 +1,26 @@
+package org.kosat
+
+data class Configuration(
+    val flp: FailedLiteralPropagation? = FailedLiteralPropagation(),
+    val restarts: Restarts = Restarts.Luby(),
+    val clauseDB: ClauseDB = ClauseDB(),
+) {
+    data class FailedLiteralPropagation(
+        val maxProbes: Int = 1000,
+        val hyperBinaryResolution: Boolean = true,
+    )
+
+    sealed interface Restarts {
+        data class Luby(val conflictCountConstant: Double = 50.0) : Restarts
+    }
+
+    data class ClauseDB(
+        val initialMaxLearntClauses: Int = 6000,
+        val maxLearntClauseIncrement: Int = 500,
+        val reduceStrategy: ReduceStrategy = ReduceStrategy.LBD,
+    ) {
+        enum class ReduceStrategy {
+            LBD,
+        }
+    }
+}

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Restarter.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Restarter.kt
@@ -1,9 +1,9 @@
 package org.kosat
 
 // used for restarts between searches (luby restarts are used now)
-class Restarter(private val solver: CDCL) {
+class Restarter(private val solver: CDCL, cfg: Configuration.Restarts.Luby) {
 
-    private val lubyMultiplierConstant = 50.0
+    private val lubyMultiplierConstant = cfg.conflictCountConstant
     private var restartNumber = lubyMultiplierConstant
     private var numberOfConflictsAfterRestart = 0
 

--- a/kosat-core/src/jvmTest/kotlin/org/kosat/DiamondTests.kt
+++ b/kosat-core/src/jvmTest/kotlin/org/kosat/DiamondTests.kt
@@ -119,7 +119,7 @@ internal class DiamondTests {
 
         val first = readCnfRequests(fileInput).first()
 
-        val solver = CDCL(first.clauses.map { it.toClause() }, first.vars)
+        val solver = CDCL(Configuration(), first.clauses.map { it.toClause() }, first.vars)
 
         var res = "OK"
 

--- a/kosat-core/src/jvmTest/kotlin/org/kosat/ManualTest.kt
+++ b/kosat-core/src/jvmTest/kotlin/org/kosat/ManualTest.kt
@@ -13,7 +13,7 @@ internal class ManualTest {
         val clauses = cnf.clauses.map { lits ->
             Clause(lits.map { Lit.fromExternal(it) }.toMutableList())
         }
-        val solver = CDCL(clauses, cnf.numVars)
+        val solver = CDCL(Configuration(), clauses, cnf.numVars)
         val model = solver.solve()
         println("model = $model")
     }


### PR DESCRIPTION
Moves most of the configuration options to a separate `Configuration` class, which should represent a type safe wrapper around all global solver settings. The type safety is achieved through the use of algebraic types (and might be a slight overkill). It still requires a lot of work to be done, such as running the test suite multiple times with different configurations.