### PR TITLE
Human-readable `toString` for Solver Types

### DIFF
--- a/kosat-core/src/commonMain/kotlin/org/kosat/Clause.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Clause.kt
@@ -27,4 +27,13 @@ data class Clause(
             return Clause(lits)
         }
     }
+
+    override fun toString(): String {
+        val flags = sequenceOf(
+            if (learnt) "L" else ".",
+            if (deleted) "D" else "."
+        ).joinToString("")
+
+        return "Cl(${lits.joinToString(" ")} | flg=$flags act=${activity.round(2)} lbd=$lbd)"
+    }
 }

--- a/kosat-core/src/commonMain/kotlin/org/kosat/SolverTypes.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/SolverTypes.kt
@@ -60,6 +60,10 @@ value class Lit(val inner: Int) {
             return Lit(((abs(lit) - 1) shl 1) + if (lit < 0) 1 else 0)
         }
     }
+
+    override fun toString(): String {
+        return if (isPos) variable.toString() else "-$variable"
+    }
 }
 
 operator fun <T> List<T>.get(lit: Lit): T {
@@ -81,6 +85,10 @@ value class Var(val index: Int) {
 
     /** A literal of negation of that variable */
     val negLit: Lit get() = Lit((index shl 1) or 1)
+
+    override fun toString(): String {
+        return "x${index + 1}"
+    }
 }
 
 operator fun <T> List<T>.get(variable: Var): T {


### PR DESCRIPTION
Adds human-readable `toString` overwrite for `Clause`, `Lit` and `Variable` with DIMACS numbering. A little opinionated, but nice for debugging.