### PR TITLE
Equivalent Literal Substitution

### DIFF
--- a/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
@@ -32,6 +32,7 @@ class Assignment(private val solver: CDCL) {
      * @return the value of the variable, assuming that it is not substituted.
      */
     fun value(v: Var): LBool {
+        check(varData[v].substitution == null)
         return value[v]
     }
 
@@ -39,6 +40,11 @@ class Assignment(private val solver: CDCL) {
      * @return the value of the literal, assuming that it is not substituted.
      */
     fun value(lit: Lit): LBool {
+        // TODO: It would be nice to have this assertion,
+        //       however, there are too many moving pieces at the moment
+        //       and enabling this will require a lot of additional
+        //       isSubstituted checks.
+        // check(varData[lit.variable].substitution == null)
         return value[lit.variable] xor lit.isNeg
     }
 

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
@@ -9,6 +9,9 @@ data class VarState(
 
     /** Index of the variable in the trail */
     var trailIndex: Int = -1,
+
+    /** A literal which is used to substitute this variable after Equivalent Literal Substitution */
+    var substitution: Lit? = null,
 )
 
 class Assignment(private val solver: CDCL) {

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
@@ -47,13 +47,31 @@ class Assignment(private val solver: CDCL) {
         return valueAfterSubstitution(lit.variable) xor lit.isNeg
     }
 
-    fun markSubstituted(variable: Var, substitution: Lit) {
-        check(varData[variable].substitution == null)
-        varData[variable].substitution = substitution
+    fun markSubstituted(lit: Lit, substitution: Lit) {
+        check(varData[lit.variable].substitution == null)
+        varData[lit.variable].substitution = substitution xor lit.isNeg
     }
 
     fun fixNestedSubstitutions() {
+        for (varIndex in 0 until numberOfVariables) {
+            val variable = Var(varIndex)
+            val substitution = varData[variable].substitution ?: continue
+            val secondSubstitution = varData[substitution.variable].substitution ?: continue
+            varData[variable].substitution = secondSubstitution xor substitution.isNeg
+        }
+    }
 
+    fun substitute(lit: Lit): Lit {
+        val substitution = varData[lit.variable].substitution
+        return if (substitution != null) {
+            substitution xor lit.isNeg
+        } else {
+            lit
+        }
+    }
+
+    fun isSubstituted(v: Var): Boolean {
+        return varData[v].substitution != null
     }
 
     // fun assign(v: Var, value: LBool) {

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
@@ -65,8 +65,7 @@ class Assignment(private val solver: CDCL) {
      * Marks the literal as substituted by the given literal.
      */
     fun markSubstituted(lit: Lit, substitution: Lit) {
-        // FIXME:
-        // if (varData[lit.variable].substitution == null) numberOfSubstitutions++
+        if (varData[lit.variable].substitution == null) numberOfSubstitutions++
         varData[lit.variable].substitution = substitution xor lit.isNeg
     }
 

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
@@ -48,7 +48,6 @@ class Assignment(private val solver: CDCL) {
     }
 
     fun markSubstituted(lit: Lit, substitution: Lit) {
-        check(varData[lit.variable].substitution == null)
         varData[lit.variable].substitution = substitution xor lit.isNeg
     }
 
@@ -61,7 +60,7 @@ class Assignment(private val solver: CDCL) {
         }
     }
 
-    fun substitute(lit: Lit): Lit {
+    fun getSubstitutionOf(lit: Lit): Lit {
         val substitution = varData[lit.variable].substitution
         return if (substitution != null) {
             substitution xor lit.isNeg

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
@@ -106,20 +106,12 @@ class Assignment(private val solver: CDCL) {
         return varData[v].substitution != null
     }
 
-    // fun assign(v: Var, value: LBool) {
-    //     value[v] = value
-    // }
-
     fun unassign(v: Var) {
         value[v] = LBool.UNDEF
         varData[v].reason = null
         varData[v].level = -1
         varData[v].trailIndex = -1
     }
-
-    // fun varData(v: Var): VarState {
-    //     return varData[v]
-    // }
 
     fun reason(v: Var): Clause? {
         return varData[v].reason

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
@@ -32,7 +32,7 @@ class Assignment(private val solver: CDCL) {
      * @return the value of the variable, assuming that it is not substituted.
      */
     fun value(v: Var): LBool {
-        check(varData[v].substitution == null)
+        require(varData[v].substitution == null)
         return value[v]
     }
 
@@ -44,7 +44,7 @@ class Assignment(private val solver: CDCL) {
         //       however, there are too many moving pieces at the moment
         //       and enabling this will require a lot of additional
         //       isSubstituted checks.
-        // check(varData[lit.variable].substitution == null)
+        // require(varData[lit.variable].substitution == null)
         return value[lit.variable] xor lit.isNeg
     }
 

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
@@ -18,6 +18,9 @@ class Assignment(private val solver: CDCL) {
     val value: MutableList<LBool> = mutableListOf()
     val varData: MutableList<VarState> = mutableListOf()
     val trail: MutableList<Lit> = mutableListOf()
+    val numberOfVariables get() = value.size
+    private var numberOfSubstitutions = 0
+    val numberOfActiveVariables get() = numberOfVariables - numberOfSubstitutions
 
     var decisionLevel: Int = 0
     var qhead: Int = 0
@@ -29,6 +32,28 @@ class Assignment(private val solver: CDCL) {
 
     fun value(lit: Lit): LBool {
         return value[lit.variable] xor lit.isNeg
+    }
+
+    fun valueAfterSubstitution(v: Var): LBool {
+        val substitution = varData[v].substitution
+        return if (substitution != null) {
+            value(substitution)
+        } else {
+            value(v)
+        }
+    }
+
+    fun valueAfterSubstitution(lit: Lit): LBool {
+        return valueAfterSubstitution(lit.variable) xor lit.isNeg
+    }
+
+    fun markSubstituted(variable: Var, substitution: Lit) {
+        check(varData[variable].substitution == null)
+        varData[variable].substitution = substitution
+    }
+
+    fun fixNestedSubstitutions() {
+
     }
 
     // fun assign(v: Var, value: LBool) {

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Assignment.kt
@@ -20,6 +20,8 @@ class Assignment(private val solver: CDCL) {
     val trail: MutableList<Lit> = mutableListOf()
     val numberOfVariables get() = value.size
     private var numberOfSubstitutions = 0
+
+    /** The number of not substituted variables */
     val numberOfActiveVariables get() = numberOfVariables - numberOfSubstitutions
 
     var decisionLevel: Int = 0
@@ -156,6 +158,7 @@ class Assignment(private val solver: CDCL) {
 
     fun uncheckedEnqueue(lit: Lit, reason: Clause?) {
         require(value(lit) == LBool.UNDEF)
+        require(varData[lit.variable].substitution == null)
 
         if (decisionLevel == 0) solver.dratBuilder.addClause(Clause(mutableListOf(lit)))
 

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -127,7 +127,7 @@ class CDCL {
         polarity.add(LBool.UNDEF)
     }
 
-    fun value(lit: Lit): LBool {
+    private fun value(lit: Lit): LBool {
         return assignment.value(lit)
     }
 

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -151,7 +151,7 @@ class CDCL {
 
         // If the clause contains complementary literals, ignore it as useless,
         // perform substitution otherwise
-        if (simplifyAndCheckComplimentary(clause.lits)) return
+        if (substituteAndCheckComplimentary(clause.lits)) return
 
         when (clause.size) {
             // Empty clause is an immediate UNSAT
@@ -179,7 +179,7 @@ class CDCL {
      * then checks if the list contains a literal and its negation
      * and returns true if so.
      */
-    private fun simplifyAndCheckComplimentary(lits: MutableList<Lit>): Boolean {
+    private fun substituteAndCheckComplimentary(lits: MutableList<Lit>): Boolean {
         for (i in 0 until lits.size) {
             lits[i] = assignment.getSubstitutionOf(lits[i])
         }
@@ -241,7 +241,7 @@ class CDCL {
 
         // Check if the assumptions are trivially unsatisfiable,
         // performing substitutions along the way if required
-        if (simplifyAndCheckComplimentary(assumptions)) return finishWithAssumptionsUnsat()
+        if (substituteAndCheckComplimentary(assumptions)) return finishWithAssumptionsUnsat()
 
         // Clean up from the previous solve
         if (assignment.decisionLevel > 0) backtrack(0)
@@ -522,7 +522,7 @@ class CDCL {
 
         // We must update assumptions after ELS, because it can
         // substitute literals in assumptions, and even derive UNSAT.
-        if (simplifyAndCheckComplimentary(assumptions)) {
+        if (substituteAndCheckComplimentary(assumptions)) {
             return finishWithAssumptionsUnsat()
         }
 
@@ -664,7 +664,7 @@ class CDCL {
             if (!willChange) continue
 
             val newLits = clause.lits.toMutableList()
-            val containsComplementary = simplifyAndCheckComplimentary(newLits)
+            val containsComplementary = substituteAndCheckComplimentary(newLits)
             // Note that clause cannot become empty,
             // however, it can contain complementary literals.
             // We simply remove such clauses.

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -1050,10 +1050,6 @@ class CDCL {
 
             check(value(lit) == LBool.TRUE)
 
-            if (value(lit) == LBool.FALSE) {
-                return assignment.reason(lit.variable)
-            }
-
             // Checking the list of clauses watching the negation of the literal.
             // In those clauses, both of the watched literals might be false,
             // which can either lead to a conflict (all literals in clause are false),

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -674,9 +674,7 @@ class CDCL {
                 // so we have to add the rest manually
                 if (newClause.size == 1 || !clause.learnt) dratBuilder.addClause(newClause)
                 if (newClause.size == 1) {
-                    if (!assignment.enqueue(newClause[0], null)) {
-                        return finishWithUnsat()
-                    }
+                    check(assignment.enqueue(newClause[0], null))
                 } else {
                     attachClause(newClause)
                 }

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -620,9 +620,11 @@ class CDCL {
                         }
 
                         // We can choose any literal from the SCC as a
-                        // representative, so we choose v
+                        // representative, so we choose the minimal one to
+                        // avoid re-substitution to a different literal later
+                        val repr = scc.minBy { it.inner }
                         for (w in scc) {
-                            if (w != v) assignment.markSubstituted(w, v)
+                            if (w != repr) assignment.markSubstituted(w, repr)
                         }
                         // Note that there is no need to add clauses to the proof
                         totalSubstituted += scc.size - 1

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -665,11 +665,7 @@ class CDCL {
                 if (clause.deleted) continue
                 if (clause.size != 2) continue
 
-                val other = if (clause[0].variable == lit.variable) {
-                    clause[1]
-                } else {
-                    clause[0]
-                }
+                val other = clause.otherWatch(lit.neg)
 
                 when (value(other)) {
                     // if the other literal is true, the
@@ -772,13 +768,11 @@ class CDCL {
                 if (assignment.trailIndex(lcaVar) > assignment.trailIndex(litVar)) {
                     check(assignment.reason(lcaVar)!!.size == 2)
                     val (a, b) = assignment.reason(lcaVar)!!.lits
-                    // TODO: this can be done with xor,
-                    //   will fix after merging feature/assignment
-                    lca = if (a == lca) b.neg else a.neg
+                    lca = lca.differentAmong2(a, b).neg
                 } else {
                     check(assignment.reason(litVar)!!.size == 2)
                     val (a, b) = assignment.reason(litVar)!!.lits
-                    lit = if (a == lit) b.neg else a.neg
+                    lit = lit.differentAmong2(a, b).neg
                 }
             }
         }

--- a/kosat-core/src/commonMain/kotlin/org/kosat/Clause.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/Clause.kt
@@ -21,6 +21,10 @@ data class Clause(
         return lits.map { it.toDimacs() }
     }
 
+    fun otherWatch(lit: Lit): Lit {
+        return lit.differentAmong2(lits[0], lits[1])
+    }
+
     companion object {
         fun fromDimacs(clause: List<Int>): Clause {
             val lits = clause.map { Lit.fromDimacs(it) }.toMutableList()

--- a/kosat-core/src/commonMain/kotlin/org/kosat/SolverTypes.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/SolverTypes.kt
@@ -64,6 +64,11 @@ value class Lit(val inner: Int) {
         return if (isPos) v else -v
     }
 
+    fun differentAmong2(lit1: Lit, lit2: Lit): Lit {
+        check(this == lit1 || this == lit2)
+        return Lit(inner xor lit1.inner xor lit2.inner)
+    }
+
     companion object {
         fun fromDimacs(lit: Int): Lit {
             val v = abs(lit) - 1 // 0-based variables index

--- a/kosat-core/src/commonMain/kotlin/org/kosat/SolverTypes.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/SolverTypes.kt
@@ -69,6 +69,10 @@ value class Lit(val inner: Int) {
         return Lit(inner xor lit1.inner xor lit2.inner)
     }
 
+    infix fun xor(b: Boolean): Lit {
+        return Lit(inner xor b.toInt())
+    }
+
     companion object {
         fun fromDimacs(lit: Int): Lit {
             val v = abs(lit) - 1 // 0-based variables index

--- a/kosat-core/src/commonMain/kotlin/org/kosat/SolverTypes.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/SolverTypes.kt
@@ -64,6 +64,10 @@ value class Lit(val inner: Int) {
         return if (isPos) v else -v
     }
 
+    /**
+     * Returns a literal not equal to `this`, among two given literals,
+     * assuming that `this` is (at least) one of them.
+     */
     fun differentAmong2(lit1: Lit, lit2: Lit): Lit {
         check(this == lit1 || this == lit2)
         return Lit(inner xor lit1.inner xor lit2.inner)

--- a/kosat-core/src/commonMain/kotlin/org/kosat/VariableSelector.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/VariableSelector.kt
@@ -215,8 +215,8 @@ class VSIDS(private var numberOfVariables: Int = 0) : VariableSelector() {
         }
         // if there is undefined assumption pick it, other way pick best choice
         return assumptions.firstOrNull {
-            assignment.value(it) == LBool.UNDEF &&
-                assignment.varData[it.variable].substitution == null
+            assignment.varData[it.variable].substitution == null &&
+                assignment.value(it) == LBool.UNDEF
         } ?: getMaxActivityVariable(assignment).posLit
     }
 

--- a/kosat-core/src/commonMain/kotlin/org/kosat/VariableSelector.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/VariableSelector.kt
@@ -214,8 +214,10 @@ class VSIDS(private var numberOfVariables: Int = 0) : VariableSelector() {
             return null
         }
         // if there is undefined assumption pick it, other way pick best choice
-        return assumptions.firstOrNull { assignment.value(it) == LBool.UNDEF }
-            ?: getMaxActivityVariable(assignment).posLit
+        return assumptions.firstOrNull {
+            assignment.value(it) == LBool.UNDEF &&
+                assignment.varData[it.variable].substitution == null
+        } ?: getMaxActivityVariable(assignment).posLit
     }
 
     override fun backTrack(variable: Var) {

--- a/kosat-core/src/commonMain/kotlin/org/kosat/VariableSelector.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/VariableSelector.kt
@@ -215,8 +215,7 @@ class VSIDS(private var numberOfVariables: Int = 0) : VariableSelector() {
         }
         // if there is undefined assumption pick it, other way pick best choice
         return assumptions.firstOrNull {
-            assignment.varData[it.variable].substitution == null &&
-                assignment.value(it) == LBool.UNDEF
+            assignment.value(it) == LBool.UNDEF
         } ?: getMaxActivityVariable(assignment).posLit
     }
 
@@ -231,7 +230,7 @@ class VSIDS(private var numberOfVariables: Int = 0) : VariableSelector() {
         while (true) {
             require(activityPQ.size > 0)
             val v = activityPQ.pop()
-            if (assignment.value(Var(v)) == LBool.UNDEF) {
+            if (assignment.varData[Var(v)].substitution == null && assignment.value(Var(v)) == LBool.UNDEF) {
                 return Var(v)
             }
         }

--- a/kosat-core/src/commonMain/kotlin/org/kosat/util.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/util.kt
@@ -9,3 +9,7 @@ fun Double.round(decimals: Int): Double {
     repeat(decimals) { multiplier *= 10 }
     return kotlin.math.round(this * multiplier) / multiplier
 }
+
+fun Boolean.toInt(): Int {
+    return if (this) 1 else 0
+}

--- a/kosat-core/src/jvmTest/kotlin/org/kosat/DiamondTests.kt
+++ b/kosat-core/src/jvmTest/kotlin/org/kosat/DiamondTests.kt
@@ -100,6 +100,7 @@ internal class DiamondTests {
             }
             println("MiniSat conflicts: ${backend.numberOfConflicts}")
             println("Minisat decisions: ${backend.numberOfDecisions}")
+            println("MiniSat result: $result")
 
             result
         }
@@ -234,7 +235,7 @@ internal class DiamondTests {
 
     @ParameterizedTest(name = "{1}")
     @MethodSource("getBenchmarkFiles")
-    @Disabled
+    // @Disabled
     fun testOnBenchmarks(file: File, testName: String) {
         println("# Testing on: $file")
         runTest(file, CNF.from(file.toOkioPath()))

--- a/kosat-core/src/jvmTest/kotlin/org/kosat/DiamondTests.kt
+++ b/kosat-core/src/jvmTest/kotlin/org/kosat/DiamondTests.kt
@@ -235,7 +235,7 @@ internal class DiamondTests {
 
     @ParameterizedTest(name = "{1}")
     @MethodSource("getBenchmarkFiles")
-    // @Disabled
+    @Disabled
     fun testOnBenchmarks(file: File, testName: String) {
         println("# Testing on: $file")
         runTest(file, CNF.from(file.toOkioPath()))

--- a/kosat-core/src/jvmTest/kotlin/org/kosat/ManualTest.kt
+++ b/kosat-core/src/jvmTest/kotlin/org/kosat/ManualTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.Test
 internal class ManualTest {
     @Test
     fun testManual() {
-        val path = "src/jvmTest/resources/testCover/cover/cover0033.cnf".toPath()
+        val path = "src/jvmTest/resources/testCover/cover/cover0025.cnf".toPath()
         val cnf = CNF.from(path)
         val clauses = cnf.clauses.map { lits ->
             Clause(lits.map { Lit.fromDimacs(it) }.toMutableList())
@@ -20,9 +20,8 @@ internal class ManualTest {
         val model = solver.solve()
         println("${solver.getModel()}")
         println("model = $model")
-        val model2 = solver.solve(listOf(Lit.fromDimacs(1)))
-        val model3 = solver.solve(listOf(Lit.fromDimacs(2), Lit.fromDimacs(-1)))
+        val model2 = solver.solve(listOf(Lit.fromDimacs(22)))
         println("model = $model2")
-        println("model = $model3")
+        // println("${solver.getModel()}")
     }
 }


### PR DESCRIPTION
Adds Equivalent Literal Substitution, or ELS, to the preprocessing.

Note on performance: this heuristic currently causes a significant (about x1.5) slowdown, not because it is slow by itself (the entire preprocessing only takes about 7% of total solve time), but because it causes ~~the current implementation of `VariableSeletor` to work slowly~~, something else to work slowly (?). I will fix it later.