### PR TITLE
Fix a few bugs in Equivalent Literal Substitution

### DIFF
--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -536,14 +536,6 @@ class CDCL {
             equivalentLiteralSubstitution()?.let { return it }
         }
 
-        // We must update assumptions after ELS, because it can
-        // substitute literals in assumptions, and even derive UNSAT.
-        if (sortDedupAndCheckComplimentary(assumptions)) {
-            return finishWithAssumptionsUnsat()
-        }
-
-        variableSelector.initAssumptions(assumptions)
-
         return null
     }
 

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -700,6 +700,14 @@ class CDCL {
             reconstructionStack.pushSubstitution(representatives[v]!!, v.posLit)
         }
 
+        // We cannot remove clauses that contain substituted literals right
+        // away, because we need to build the proof, and removing clauses right
+        // after performing substitution may cause the clauses which caused the
+        // equivalence to be removed, which will make the proof invalid.
+        // Instead, we remember which clauses we no longer need, and remove them
+        // later.
+        val clausesToDelete = mutableListOf<Clause>()
+
         // Replace clauses which might have simplified due to substitution
         for (clause in db.clauses + db.learnts) {
             if (clause.deleted) continue
@@ -721,6 +729,10 @@ class CDCL {
                 }
             }
 
+            clausesToDelete.add(clause)
+        }
+
+        for (clause in clausesToDelete) {
             markDeleted(clause)
         }
 

--- a/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
+++ b/kosat-core/src/commonMain/kotlin/org/kosat/CDCL.kt
@@ -586,10 +586,12 @@ class CDCL {
         // Total number of literals substituted
         var totalSubstituted = 0
 
+        val recursionLimit = 5000
+
         // Tarjan's algorithm, returns the lowest number of all reachable nodes
         // from the given node, or null if the node is in a cycle with the
         // negation of itself, and the problem is UNSAT
-        fun dfs(v: Lit): Int? {
+        fun dfs(v: Lit, recursionDepthLeft: Int): Int? {
             check(value(v) == LBool.UNDEF)
             check(marks[v] == 0)
 
@@ -600,9 +602,13 @@ class CDCL {
             num[v] = counter
             var lowest = counter
 
+            if (recursionDepthLeft == 0) {
+                return counter
+            }
+
             for (u in binaryImplicationsFrom(v)) {
                 if (marks[u] == markUnvisited) {
-                    val otherLowest = dfs(u) ?: return null
+                    val otherLowest = dfs(u, recursionDepthLeft - 1) ?: return null
                     lowest = min(otherLowest, lowest)
                 } else if (marks[u] != markProcessed) {
                     lowest = min(lowest, num[u])
@@ -678,7 +684,7 @@ class CDCL {
                 value(lit) != LBool.UNDEF
             ) continue
 
-            dfs(lit) ?: return finishWithUnsat()
+            dfs(lit, recursionLimit) ?: return finishWithUnsat()
         }
 
         if (totalSubstituted == 0) return null


### PR DESCRIPTION
Fixes multiple bugs in ELS:
- Adds recursion limit to DFS, preventing possible stack overflow.
- Removes redundant updates of variable selector after ELS. This is no longer needed since assumptions are now frozen.
- Fixes bug with order of clause addition/deletion in proof. Very rare bug that was only caught by disabling HBR.